### PR TITLE
Fix various typos

### DIFF
--- a/cinelerra/attachmentpoint.C
+++ b/cinelerra/attachmentpoint.C
@@ -83,7 +83,7 @@ int AttachmentPoint::render_init()
 	if(plugin_server && plugin->on)
 	{
 // Start new plugin servers if the number of nodes changed.
-// The number of nodes can change independantly of the module's 
+// The number of nodes can change independently of the module's 
 // attachment count.
 		if(virtual_plugins.total != new_virtual_plugins.total)
 		{

--- a/cinelerra/audiooss.C
+++ b/cinelerra/audiooss.C
@@ -332,7 +332,7 @@ int64_t AudioOSS::device_position()
 	{
 //printf("AudioOSS::device_position %d %d %d\n", info.bytes, device->get_obits(), device->get_ochannels());
 // workaround for ALSA OSS emulation driver's bug
-// the problem is that if the first write to sound device was not full lenght fragment then 
+// the problem is that if the first write to sound device was not full length fragment then 
 // _GETOPTR returns insanely large numbers at first moments of play
 		if (info.bytes > 2100000000) 
 			return 0;

--- a/cinelerra/avc1394control.C
+++ b/cinelerra/avc1394control.C
@@ -53,7 +53,7 @@ void AVC1394Control::initialize()
 		if(!errno)
 		{
 //printf("AVC1394Control::initialize(): 3\n");
-			fprintf(stderr, "AVC1394Control::initialize(): Not Compatable!\n");
+			fprintf(stderr, "AVC1394Control::initialize(): Not Compatible!\n");
 		} 
 		else 
 		{

--- a/cinelerra/awindowgui.C
+++ b/cinelerra/awindowgui.C
@@ -229,7 +229,7 @@ void AssetPicon::create_objects()
 // 						pixmap_h,
 // 						BC_RGB888, 
 // 						BC_RGB888,
-// 						0,         /* When transfering BC_RGBA8888 to non-alpha this is the background color in 0xRRGGBB hex */
+// 						0,         /* When transferring BC_RGBA8888 to non-alpha this is the background color in 0xRRGGBB hex */
 // 						0,       /* For planar use the luma rowspan */
 // 						0);     /* For planar use the luma rowspan */
 // 

--- a/cinelerra/awindowgui.h
+++ b/cinelerra/awindowgui.h
@@ -128,7 +128,7 @@ public:
 	AWindowDivider *divider;
 
 // Store data to speed up responses
-// Persistant data for listboxes
+// Persistent data for listboxes
 // All assets in current EDL
 	ArrayList<BC_ListBoxItem*> assets;
 	ArrayList<BC_ListBoxItem*> folders;

--- a/cinelerra/brender.h
+++ b/cinelerra/brender.h
@@ -38,7 +38,7 @@
 // rendering or foreground rendering can be happening but not both.
 
 // A BRenderThread client runs in the background and a BRender object 
-// interfaces the main window.  The BRender client recieves commands to
+// interfaces the main window.  The BRender client receives commands to
 // restart, start, and stop background rendering on its own time to avoid 
 // interrupting the main window.
 

--- a/cinelerra/buz.h
+++ b/cinelerra/buz.h
@@ -130,7 +130,7 @@ struct buz_params
 
    int  quality;                  /* Measure for quality of compressed images.
                                      Scales linearly with the size of the compressed images.
-                                     Must be beetween 0 and 100, 100 is a compression
+                                     Must be between 0 and 100, 100 is a compression
                                      ratio of 1:4 */
 
    int  odd_even;                 /* Which field should come first ??? */
@@ -144,8 +144,8 @@ struct buz_params
 
    unsigned long jpeg_markers;    /* Which markers should go into the JPEG output.
                                      Unless you exactly know what you do, leave them untouched.
-                                     Inluding less markers will make the resulting code
-                                     smaller, but there will be fewer aplications
+                                     Including less markers will make the resulting code
+                                     smaller, but there will be fewer applications
                                      which can read it.
                                      The presence of the APP and COM marker is
                                      influenced by APP0_len and COM_len ONLY! */
@@ -153,7 +153,7 @@ struct buz_params
 #define JPEG_MARKER_DQT (1<<4)    /* Define Quantization Tables */
 #define JPEG_MARKER_DRI (1<<5)    /* Define Restart Interval */
 #define JPEG_MARKER_COM (1<<6)    /* Comment segment */
-#define JPEG_MARKER_APP (1<<7)    /* App segment, driver will allways use APP0 */
+#define JPEG_MARKER_APP (1<<7)    /* App segment, driver will always use APP0 */
 
    int  VFIFO_FB;                 /* Flag for enabling Video Fifo Feedback.
                                      If this flag is turned on and JPEG decompressing
@@ -237,7 +237,7 @@ struct buz
    struct video_device video_dev;
    struct i2c_bus i2c;
 
-   int initialized;             /* flag if buz has been correctly initalized */
+   int initialized;             /* flag if buz has been correctly initialized */
    int user;                    /* number of current users (0 or 1) */
 
    unsigned short id;           /* number of this device */

--- a/cinelerra/cache.h
+++ b/cinelerra/cache.h
@@ -119,7 +119,7 @@ private:
 
 // to prevent one from checking the same asset out before it's checked in
 // yet without blocking the asset trying to get checked in
-// use a seperate mutex for checkouts and checkins
+// use a separate mutex for checkouts and checkins
 	Mutex *total_lock;
 	Condition *check_out_lock;
 // Copy of EDL

--- a/cinelerra/channeledit.C
+++ b/cinelerra/channeledit.C
@@ -673,7 +673,7 @@ int ChannelEditPicture::handle_event()
 
 
 
-// ========================= confirm overwrite by channel scannin
+// ========================= confirm overwrite by channel scanning
 
 
 ConfirmScan::ConfirmScan(ChannelEditWindow *gui, int x, int y)

--- a/cinelerra/dcraw.c
+++ b/cinelerra/dcraw.c
@@ -3846,7 +3846,7 @@ void CLASS remove_zeroes()
 }
 
 /*
-   Seach from the current directory up to the root looking for
+   Search from the current directory up to the root looking for
    a ".badpixels" file, and fix those pixels now.
  */
 void CLASS bad_pixels (const char *cfname)
@@ -4855,7 +4855,7 @@ void CLASS xtrans_interpolate (int passes)
 		  homo[d][row][col]++;
 	}
 
-/* Average the most homogenous pixels for the final result:	*/
+/* Average the most homogeneous pixels for the final result:	*/
       if (height-top < TS+4) mrow = height-top+2;
       if (width-left < TS+4) mcol = width-left+2;
       for (row = MIN(top,8); row < mrow-8; row++)
@@ -4971,7 +4971,7 @@ void CLASS ahd_interpolate()
 		homo[d][tr][tc]++;
 	}
       }
-/*  Combine the most homogenous pixels for the final result:	*/
+/*  Combine the most homogeneous pixels for the final result:	*/
       for (row=top+3; row < top+TS-3 && row < height-5; row++) {
 	tr = row-top;
 	for (col=left+3; col < left+TS-3 && col < width-5; col++) {

--- a/cinelerra/dcraw.c.bak2
+++ b/cinelerra/dcraw.c.bak2
@@ -1988,7 +1988,7 @@ void CLASS foveon_interpolate()
 }
 
 /*
-   Seach from the current directory up to the root looking for
+   Search from the current directory up to the root looking for
    a ".badpixels" file, and fix those pixels now.
  */
 void CLASS bad_pixels()
@@ -4786,8 +4786,8 @@ int CLASS dcraw_main (int argc, char **argv)
     "\n-x <num>  Set exposure compensation in stops (default 0.00)"
     "\n-S <num>  Adjust saturation"
     "\n-C <num>  Adjust contrast"
-    "\n-k <num>  Set interpolation threshold paramater k1\n\t  for T = k1*Min + k2 * (Max - Min) (default = 1.5)"
-    "\n-K <num>  Set interpolation threshold paramater k2\n\t  for T = k1*Min + k2 * (Max - Min) (default = 0.5)"
+    "\n-k <num>  Set interpolation threshold parameter k1\n\t  for T = k1*Min + k2 * (Max - Min) (default = 1.5)"
+    "\n-K <num>  Set interpolation threshold parameter k2\n\t  for T = k1*Min + k2 * (Max - Min) (default = 0.5)"
     "\n-j <num>  Set parameter for color matrix"
     "\n-1        Write 24-bpp PPM using 16 bit calculation"
     "\n-2        Write 24-bpp PPM (default)"

--- a/cinelerra/device1394output.C
+++ b/cinelerra/device1394output.C
@@ -680,7 +680,7 @@ void Device1394Output::write_frame(VFrame *input)
 				MIN(temp_frame2->get_h(), input->get_h()),
 				input->get_color_model(), 
 				BC_YUV422,
-				0,         /* When transfering BC_RGBA8888 to non-alpha this is the background color in 0xRRGGBB hex */
+				0,         /* When transferring BC_RGBA8888 to non-alpha this is the background color in 0xRRGGBB hex */
 				input->get_bytes_per_line(),       /* For planar use the luma rowspan */
 				temp_frame2->get_bytes_per_line());     /* For planar use the luma rowspan */
 

--- a/cinelerra/edit.h
+++ b/cinelerra/edit.h
@@ -109,7 +109,7 @@ public:
 
 	void insert_transition(char  *title, KeyFrame *keyframe);
 	void detach_transition();
-// Determine if silence depending on existance of asset or plugin title
+// Determine if silence depending on existence of asset or plugin title
 	virtual int silence();
 
 // Media edit information

--- a/cinelerra/edl.inc
+++ b/cinelerra/edl.inc
@@ -86,7 +86,7 @@ class EDL;
 
 
 #define CWINDOW_NONE -1   // the new value for none
-//#define CWINDOW_PROTECT     0 // skip 1 for backwards compatability
+//#define CWINDOW_PROTECT     0 // skip 1 for backwards compatibility
 #define CWINDOW_FIRST 1 // first operation
 #define CWINDOW_ZOOM        1
 #define CWINDOW_MASK        2

--- a/cinelerra/file.C
+++ b/cinelerra/file.C
@@ -1534,7 +1534,7 @@ int File::write_samples(Samples **buffer, int64_t len)
 	{
 		write_lock->lock("File::write_samples");
 
-// Convert to arrays for backwards compatability
+// Convert to arrays for backwards compatibility
 		double *temp[asset->channels];
 		for(int i = 0; i < asset->channels; i++)
 		{

--- a/cinelerra/fileavi.C
+++ b/cinelerra/fileavi.C
@@ -666,7 +666,7 @@ void FileAVI::get_parameters(BC_WindowBase *parent_window,
 int FileAVI::set_audio_position(int64_t x)
 {
 #ifdef USE_AVIFILE
-// quicktime sets positions for each track seperately so store position in audio_position
+// quicktime sets positions for each track separately so store position in audio_position
 	if(x >= 0 && x < asset->audio_length)
 		return astream_in[file->current_layer]->Seek(x);
 	else

--- a/cinelerra/fileexr.C
+++ b/cinelerra/fileexr.C
@@ -551,7 +551,7 @@ int FileEXR::write_frame(VFrame *frame, VFrame *data, FrameWriterUnit *unit)
 			asset->height,
 			frame->get_color_model(), 
 			native_cmodel,
-			0,         /* When transfering BC_RGBA8888 to non-alpha this is the background color in 0xRRGGBB hex */
+			0,         /* When transferring BC_RGBA8888 to non-alpha this is the background color in 0xRRGGBB hex */
 			asset->width,       /* For planar use the luma rowspan */
 			asset->height);
 		output_frame = exr_unit->temp_frame;

--- a/cinelerra/filelist.C
+++ b/cinelerra/filelist.C
@@ -435,7 +435,7 @@ int FileList::read_frame(VFrame *frame)
 				asset->height,
 				temp->get_color_model(), 
 				frame->get_color_model(),
-				0,         /* When transfering BC_RGBA8888 to non-alpha this is the background color in 0xRRGGBB hex */
+				0,         /* When transferring BC_RGBA8888 to non-alpha this is the background color in 0xRRGGBB hex */
 				temp->get_w(),       /* For planar use the luma rowspan */
 				frame->get_w());
 		}

--- a/cinelerra/filemov.C
+++ b/cinelerra/filemov.C
@@ -752,7 +752,7 @@ int64_t FileMOV::get_audio_length()
 int FileMOV::set_audio_position(int64_t x)
 {
 	if(!fd) return 1;
-// quicktime sets positions for each track seperately so store position in audio_position
+// quicktime sets positions for each track separately so store position in audio_position
 	if(x >= 0 && x < asset->audio_length)
 		return quicktime_set_audio_position(fd, x, 0);
 	else

--- a/cinelerra/filempeg.C
+++ b/cinelerra/filempeg.C
@@ -57,7 +57,7 @@
 
 
 
-// M JPEG dependancies
+// M JPEG dependencies
 static double frame_rate_codes[] = 
 {
 	0,

--- a/cinelerra/filempeg.C.bak2
+++ b/cinelerra/filempeg.C.bak2
@@ -40,7 +40,7 @@
 
 
 
-// M JPEG dependancies
+// M JPEG dependencies
 static double frame_rate_codes[] = 
 {
 	0,

--- a/cinelerra/fileogg.C
+++ b/cinelerra/fileogg.C
@@ -316,7 +316,7 @@ int FileOGG::open_file(int rd, int wr)
 
 		if(asset->video_data)
 		{
-			ogg_stream_init (&tf->to, rand ());    /* oops, add one ot the above */
+			ogg_stream_init (&tf->to, rand ());    /* oops, add one to the above */
 		
 			theora_info_init (&tf->ti);
 			

--- a/cinelerra/fileogg.h
+++ b/cinelerra/fileogg.h
@@ -86,7 +86,7 @@ typedef struct
 	sync_window_t *audiosync;
 	sync_window_t *videosync;
 	
-    //to do some manual page flusing
+    //to do some manual page flushing
     int v_pkg;
     int a_pkg;
 

--- a/cinelerra/filepng.C
+++ b/cinelerra/filepng.C
@@ -296,7 +296,7 @@ int FilePNG::write_frame(VFrame *frame, VFrame *data, FrameWriterUnit *unit)
 			asset->height,
 			frame->get_color_model(), 
 			png_unit->temp_frame->get_color_model(),
-			0,         /* When transfering BC_RGBA8888 to non-alpha this is the background color in 0xRRGGBB hex */
+			0,         /* When transferring BC_RGBA8888 to non-alpha this is the background color in 0xRRGGBB hex */
 			asset->width,       /* For planar use the luma rowspan */
 			asset->height);
 		

--- a/cinelerra/filepng.C.orig
+++ b/cinelerra/filepng.C.orig
@@ -290,7 +290,7 @@ int FilePNG::write_frame(VFrame *frame, VFrame *data, FrameWriterUnit *unit)
 			asset->height,
 			frame->get_color_model(), 
 			png_unit->temp_frame->get_color_model(),
-			0,         /* When transfering BC_RGBA8888 to non-alpha this is the background color in 0xRRGGBB hex */
+			0,         /* When transferring BC_RGBA8888 to non-alpha this is the background color in 0xRRGGBB hex */
 			asset->width,       /* For planar use the luma rowspan */
 			asset->height);
 		

--- a/cinelerra/filestdout.h
+++ b/cinelerra/filestdout.h
@@ -86,7 +86,7 @@ public:
 
 // temporary interleaved audio buffer
 	uint8_t *temp_samples;
-// bytes allocaed
+// bytes allocated
 	int temp_allocated;
 // don't wrap
     int failed;

--- a/cinelerra/filethread.h
+++ b/cinelerra/filethread.h
@@ -30,7 +30,7 @@
 #include "vframe.inc"
 
 
-// This allows the file hander to write in the background without 
+// This allows the file handler to write in the background without 
 // blocking the write commands.
 // Used for recording.
 

--- a/cinelerra/filexml.h
+++ b/cinelerra/filexml.h
@@ -118,7 +118,7 @@ public:
 	int read_from_file(const char *filename, int ignore_error = 0);          // read an entire file from disk
 	int read_from_string(char *string);          // read from a string
 
-	int reallocate_string(long new_available);     // change size of string to accomodate new output
+	int reallocate_string(long new_available);     // change size of string to accommodate new output
 	int set_shared_string(char *shared_string, long available);    // force writing to a message buffer
 	int rewind();
 // Get current pointer in the string

--- a/cinelerra/iec61883output.C
+++ b/cinelerra/iec61883output.C
@@ -405,7 +405,7 @@ void IEC61883Output::write_frame(VFrame *input)
 				MIN(temp_frame2->get_h(), input->get_h()),
 				input->get_color_model(), 
 				BC_YUV422,
-				0,         /* When transfering BC_RGBA8888 to non-alpha this is the background color in 0xRRGGBB hex */
+				0,         /* When transferring BC_RGBA8888 to non-alpha this is the background color in 0xRRGGBB hex */
 				input->get_bytes_per_line(),       /* For planar use the luma rowspan */
 				temp_frame2->get_bytes_per_line());     /* For planar use the luma rowspan */
 

--- a/cinelerra/indexstate.h
+++ b/cinelerra/indexstate.h
@@ -56,7 +56,7 @@ public:
 	int index_status;     // Macro from assets.inc
 	int64_t index_zoom;      // zoom factor of index data
 	int64_t index_start;     // byte start of index data in the index file
-// Total bytes in the source file when the index was buillt
+// Total bytes in the source file when the index was built
 	int64_t index_bytes;
 	int64_t index_end, old_index_end;    // values for index build
 // for .idx files, the offset of each channel in the index buffer in floats

--- a/cinelerra/indexthread.h
+++ b/cinelerra/indexthread.h
@@ -29,7 +29,7 @@
 
 #define TOTAL_BUFFERS 2
 
-// Formerly a thread that recieved buffers from Indexfile and 
+// Formerly a thread that received buffers from Indexfile and 
 // calculated the index asynchronously.
 
 class IndexThread

--- a/cinelerra/localsession.h
+++ b/cinelerra/localsession.h
@@ -38,7 +38,7 @@ public:
 	~LocalSession();
 
 
-// Get selected range based on precidence of in/out points and
+// Get selected range based on precedence of in/out points and
 // highlighted region.
 // 1) If a highlighted selection exists it's used.
 // 2) If in_point or out_point exists they're used.
@@ -118,7 +118,7 @@ public:
 private:
 // The reason why selection ranges and inpoints have to be separate:
 // The selection position has to change to set new in points.
-// For editing functions we have a precidence for what determines
+// For editing functions we have a precedence for what determines
 // the selection.
 
 	double selectionstart, selectionend;

--- a/cinelerra/main.C
+++ b/cinelerra/main.C
@@ -362,7 +362,7 @@ COPYRIGHT_DATE);
 
 //SET_TRACE
 
-// load the initial files on seperate tracks
+// load the initial files on separate tracks
 // use a new thread so it doesn't block the GUI
 			if(filenames.total)
 			{

--- a/cinelerra/mainmenu.C
+++ b/cinelerra/mainmenu.C
@@ -438,7 +438,7 @@ int MainMenu::add_aeffect(char *title)
 	{
 		if(!strcmp(aeffect[i]->get_text(), title))     // already exists
 		{                                // swap for top effect
-			for(int j = i; j > 0; j--)   // move preceeding effects down
+			for(int j = i; j > 0; j--)   // move preceding effects down
 			{
 				aeffect[j]->set_text(aeffect[j - 1]->get_text());
 			}
@@ -480,7 +480,7 @@ int MainMenu::add_veffect(char *title)
 	{
 		if(!strcmp(veffect[i]->get_text(), title))     // already exists
 		{                                // swap for top effect
-			for(int j = i; j > 0; j--)   // move preceeding effects down
+			for(int j = i; j > 0; j--)   // move preceding effects down
 			{
 				veffect[j]->set_text(veffect[j - 1]->get_text());
 			}
@@ -526,7 +526,7 @@ int MainMenu::add_load(const char *path)
 	{
 		if(!strcmp(load[i]->get_text(), text))     // already exists
 		{                                // swap for top load
-			for(int j = i; j > 0; j--)   // move preceeding loads down
+			for(int j = i; j > 0; j--)   // move preceding loads down
 			{
 				load[j]->set_text(load[j - 1]->get_text());
 				load[j]->set_path(load[j - 1]->path);

--- a/cinelerra/messages.C
+++ b/cinelerra/messages.C
@@ -66,7 +66,7 @@ int Messages::read_message(char *text)
 
 	if((msgrcv(msgid, (struct msgbuf*)&buffer, MESSAGESIZE, input_flag, 0)) < 0)
 	{
-		printf(_("recieve message failed\n"));
+		printf(_("receive message failed\n"));
 		sleep(1);     // don't flood the screen during the loop
 		return -1;
 	}
@@ -82,7 +82,7 @@ long Messages::read_message()
 	
 	if((msgrcv(msgid, (struct msgbuf*)&buffer, MESSAGESIZE, input_flag, 0)) < 0)
 	{
-		printf(_("recieve message failed\n"));
+		printf(_("receive message failed\n"));
 		sleep(1);
 		return -1;
 	}
@@ -103,9 +103,9 @@ char* Messages::read_message_raw()
 	
 	if((msgrcv(msgid, (struct msgbuf*)&buffer, MESSAGESIZE, input_flag, 0)) < 0)
 	{
-		printf(_("recieve message failed\n"));
+		printf(_("receive message failed\n"));
 		sleep(1);
-		return "RECIEVE MESSAGE FAILED";
+		return "RECEIVE MESSAGE FAILED";
 	}
 	else
 		return buffer.text;

--- a/cinelerra/mwindow.C
+++ b/cinelerra/mwindow.C
@@ -3304,7 +3304,7 @@ int MWindow::run_script(FileXML *script)
 			{
 // Run record as a thread.  It is a terminal command.
 				;
-// Will read the complete scipt file without letting record read it if not
+// Will read the complete script file without letting record read it if not
 // terminated.
 				result2 = 1;
 			}

--- a/cinelerra/mwindow.h
+++ b/cinelerra/mwindow.h
@@ -443,7 +443,7 @@ public:
         int64_t length,
         int channel,
         int is_silence);
-// swap all occurrances of an asset with another one
+// swap all occurrences of an asset with another one
     void swap_asset(string *old_path, 
         string *new_path, 
         int old_is_silence,

--- a/cinelerra/mwindowedit.C
+++ b/cinelerra/mwindowedit.C
@@ -553,7 +553,7 @@ void MWindow::copy_keyframe(Auto *auto_)
 	FileXML file;
     edl->start_auto_copy(&file, 0, 0);
 
-// create EDL heirarchy to allow the keyframe to be pasted regularly
+// create EDL hierarchy to allow the keyframe to be pasted regularly
     file.tag.set_title("TRACK");
     int data_type = auto_->autos->track->data_type;
     int overlay_type = auto_->autos->overlay_type;

--- a/cinelerra/overlayframe.C
+++ b/cinelerra/overlayframe.C
@@ -33,7 +33,7 @@
 #include "units.h"
 #include "vframe.h"
 
-/* New resampler code; replace the original somehwat blurry engine
+/* New resampler code; replace the original somewhat blurry engine
    with a fairly standard kernel resampling core.  This could be used
    for full affine transformation but only implements scale/translate.
    Mostly reuses the old blending macro code. */
@@ -89,7 +89,7 @@ static float sinc (const float x){
 }
 
 /* All resampling (except Nearest Neighbor) is performed via
-   transformed 2D resampling kernels bult from 1D lookups. */
+   transformed 2D resampling kernels built from 1D lookups. */
 OverlayKernel::OverlayKernel(int interpolation_type){
   int i;
   this->type = interpolation_type;

--- a/cinelerra/overlayframe.C.divide
+++ b/cinelerra/overlayframe.C.divide
@@ -33,7 +33,7 @@
 #include "units.h"
 #include "vframe.h"
 
-/* New resampler code; replace the original somehwat blurry engine
+/* New resampler code; replace the original somewhat blurry engine
    with a fairly standard kernel resampling core.  This could be used
    for full affine transformation but only implements scale/translate.
    Mostly reuses the old blending macro code. */
@@ -89,7 +89,7 @@ static float sinc (const float x){
 }
 
 /* All resampling (except Nearest Neighbor) is performed via
-   transformed 2D resampling kernels bult from 1D lookups. */
+   transformed 2D resampling kernels built from 1D lookups. */
 OverlayKernel::OverlayKernel(int interpolation_type){
   int i;
   this->type = interpolation_type;

--- a/cinelerra/overlayframe.h.clamp
+++ b/cinelerra/overlayframe.h.clamp
@@ -6,11 +6,11 @@
 #include "vframe.inc"
 
 
-// Issues encoutered with overlay
+// Issues encountered with overlay
 
 // Floating point vs. int.  On alpha the floating point interpolation is about
 // 2x faster than integer interpolation.  Integer interpolation uses 32 
-// siginificant bits while floating point uses 24, however.
+// significant bits while floating point uses 24, however.
 
 // Single step vs. two step process.
 

--- a/cinelerra/overlayframe.h.floattable
+++ b/cinelerra/overlayframe.h.floattable
@@ -6,11 +6,11 @@
 #include "vframe.inc"
 
 
-// Issues encoutered with overlay
+// Issues encountered with overlay
 
 // Floating point vs. int.  On alpha the floating point interpolation is about
 // 2x faster than integer interpolation.  Integer interpolation uses 32 
-// siginificant bits while floating point uses 24, however.
+// significant bits while floating point uses 24, however.
 
 // Single step vs. two step process.
 

--- a/cinelerra/pluginclient.h
+++ b/cinelerra/pluginclient.h
@@ -358,17 +358,17 @@ public:
 	void save_defaults_xml();
 // Tell the client if the load is the defaults
 	int is_defaults();
-// must call before delete to get the GUI defualts to save
+// must call before delete to get the GUI defaults to save
     void delete_thread();
 
 	virtual void update_gui();
 	virtual void save_data(KeyFrame *keyframe);    // write the plugin settings to text in text format
 	virtual void read_data(KeyFrame *keyframe);    // read the plugin settings from the text
-	int send_hide_gui();                                    // should be sent when the GUI recieves a close event from the user
+	int send_hide_gui();                                    // should be sent when the GUI receives a close event from the user
 // Destroys the window but not the thread pointer.
 	void hide_gui();
 
-	int get_configure_change();                             // get propogated configuration change from a send_configure_change
+	int get_configure_change();                             // get propagated configuration change from a send_configure_change
 
 // Called by plugin server to update GUI with rendered data.
 // Manely for video.  Audio has to render data in update_gui
@@ -403,7 +403,7 @@ public:
 // get current camera and projector position
 	void get_camera(float *x, float *y, float *z, int64_t position);
 	void get_projector(float *x, float *y, float *z, int64_t position);
-// When this plugin is adjusted, propogate parameters back to EDL and virtual
+// When this plugin is adjusted, propagate parameters back to EDL and virtual
 // console.  This gets a keyframe from the EDL, with the position set to the
 // EDL tracking position.
 	int send_configure_change();                            
@@ -586,13 +586,13 @@ public:
 	int interactive;                // for the progress bar plugin
 	int success;
 	int total_out_buffers;          // total send buffers allocated by the server
-	int total_in_buffers;           // total recieve buffers allocated by the server
+	int total_in_buffers;           // total receive buffers allocated by the server
 	int wr, rd;                     // File permissions for fileio plugins.
 
 // These give the largest fragment the plugin is expected to handle.
 // size of a send buffer to the server
 	int64_t out_buffer_size;  
-// size of a recieve buffer from the server
+// size of a receive buffer from the server
 	int64_t in_buffer_size;   
 
 

--- a/cinelerra/plugindialog.C
+++ b/cinelerra/plugindialog.C
@@ -774,7 +774,7 @@ PluginDialogSingle::PluginDialogSingle(PluginDialog *dialog, int x, int y)
  : BC_CheckBox(x, 
  	y, 
 	dialog->thread->single_standalone, 
-	_("Attach single standlone and share others"))
+	_("Attach single standalone and share others"))
 {
 	this->dialog = dialog;
 }

--- a/cinelerra/pluginserver.C
+++ b/cinelerra/pluginserver.C
@@ -918,7 +918,7 @@ int PluginServer::read_frame(VFrame *buffer,
 //     VirtualNode
 //     Module
 // If we're a VirtualNode, read_data in the virtual plugin node handles
-//     backward propogation and produces the data.
+//     backward propagation and produces the data.
 // If we're a Module, render in the module produces the data.
 //PRINT_TRACE
 

--- a/cinelerra/pluginserver.h
+++ b/cinelerra/pluginserver.h
@@ -301,7 +301,7 @@ public:
 
 // buffers
 	int64_t out_buffer_size;   // size of a send buffer to the plugin
-	int64_t in_buffer_size;    // size of a recieve buffer from the plugin
+	int64_t in_buffer_size;    // size of a receive buffer from the plugin
 	int total_in_buffers;
 	int total_out_buffers;
 

--- a/cinelerra/pluginvclient.h
+++ b/cinelerra/pluginvclient.h
@@ -93,7 +93,7 @@ public:
 		int64_t start_position);
 
 // Called by realtime plugin to read frame from previous entity
-// framerate - framerate start_position is relative to.  Used by preceeding plugiun
+// framerate - framerate start_position is relative to.  Used by preceding plugiun
 //     to calculate output frame number.  Provided so the client can get data
 //     at a higher fidelity than provided by the EDL.
 // start_position - start of frame if forward.  end of frame if reverse.  

--- a/cinelerra/recordgui.C
+++ b/cinelerra/recordgui.C
@@ -166,7 +166,7 @@ void RecordGUI::create_objects()
 		BC_Title::calculate_h(this, "X")) + margin;
 	int button_y = 0;
 
-// Curent batch
+// Current batch
 	add_subwindow(title = new BC_Title(x, y, _("Path:")));
 	x1 = MAX(title->get_w(), x1);
 	y += pad;

--- a/cinelerra/recordmonitor.h
+++ b/cinelerra/recordmonitor.h
@@ -200,7 +200,7 @@ private:
 	void process_scope();
 	void process_hist();
 
-	int ready;   // Ready to recieve the next frame
+	int ready;   // Ready to receive the next frame
 	int done;
 	RecVideoMJPGThread *jpeg_engine;
 	RecVideoDVThread *dv_engine;

--- a/cinelerra/renderfarmclient.C
+++ b/cinelerra/renderfarmclient.C
@@ -506,7 +506,7 @@ int RenderFarmClientThread::read_package(int socket_fd, RenderPackage *package)
 // Signifies end of session.
 	if(!data) 
 	{
-//		printf(_("RenderFarmClientThread::read_package no output path recieved.\n"));
+//		printf(_("RenderFarmClientThread::read_package no output path received.\n"));
 		unlock();
 		return 1;
 	}

--- a/cinelerra/renderfarmfsclient.h
+++ b/cinelerra/renderfarmfsclient.h
@@ -27,7 +27,7 @@
 #include "renderfarmfsclient.inc"
 
 
-// This should override the stdio commands and inderect operations on any file
+// This should override the stdio commands and indirect operations on any file
 // starting with RENDERFARM_FS_PREFIX to the network.
 
 // The server runs on the master node.

--- a/cinelerra/transportque.h
+++ b/cinelerra/transportque.h
@@ -62,7 +62,7 @@ public:
 	double playbackstart;
 // Send output to device
 	int realtime;
-// Use persistant starting point
+// Use persistent starting point
 	int resume;
 
 private:

--- a/cinelerra/vdevicebuz.C
+++ b/cinelerra/vdevicebuz.C
@@ -540,7 +540,7 @@ int VDeviceBUZ::open_input_core(Channel *channel)
 // 	if(ioctl(jvideo_fd, VIDIOCGCAP, &vc) < 0)
 // 		perror("VDeviceBUZ::open_input VIDIOCGCAP");
 
-// API dependant initialization
+// API dependent initialization
 	if(ioctl(jvideo_fd, BUZIOC_G_PARAMS, &bparm) < 0)
 		perror("VDeviceBUZ::open_input BUZIOC_G_PARAMS");
 

--- a/cinelerra/vdeviceprefs.C
+++ b/cinelerra/vdeviceprefs.C
@@ -165,7 +165,7 @@ int VDevicePrefs::initialize(int creation)
 
 
 
-// Update driver dependancies in file format
+// Update driver dependencies in file format
 	if(mode == MODERECORD && dialog && !creation)
 	{
 		RecordPrefs *record_prefs = (RecordPrefs*)dialog;

--- a/cinelerra/vdevicev4l2.h
+++ b/cinelerra/vdevicev4l2.h
@@ -33,10 +33,10 @@
 #include "vdevicev4l2.inc"
 
 
-// Short delay is necessary whenn capturing a lousy source.
+// Short delay is necessary when capturing a lousy source.
 //#define BUFFER_TIMEOUT 250000
 
-// Long delay is necessary to avoid losing synchronization due to spurrious
+// Long delay is necessary to avoid losing synchronization due to spurious
 // resets.
 //#define BUFFER_TIMEOUT 10000000
 
@@ -68,7 +68,7 @@ public:
 	int total_buffers;
 	int current_inbuffer;
 	int current_outbuffer;
-// Don't block if first frame not recieved yet.
+// Don't block if first frame not received yet.
 // This frees up the GUI during driver initialization.
 	int first_frame;
 	int done;

--- a/cinelerra/videowindow.h
+++ b/cinelerra/videowindow.h
@@ -65,7 +65,7 @@ public:
 	int video_visible;
 	int video_cropping;    // Currently performing a cropping operation
 //	float zoom_factor;
-	int video_window_w;    // Horizontal size of the window independant of frame size
+	int video_window_w;    // Horizontal size of the window independent of frame size
 	VFrame **vbuffer;      // output frame buffer
 	VideoWindowGUI *gui;
 	MWindow *mwindow;

--- a/cinelerra/virtualanode.C
+++ b/cinelerra/virtualanode.C
@@ -130,8 +130,8 @@ int VirtualANode::read_data(Samples *output_temp,
 				parent_edit);
 
 
-// This is a plugin on parent module with a preceeding effect.
-// Get data from preceeding effect on parent module.
+// This is a plugin on parent module with a preceding effect.
+// Get data from preceding effect on parent module.
 	if(parent_node && 
 		(previous_plugin = parent_node->get_previous_plugin(this)))
 	{
@@ -238,7 +238,7 @@ int VirtualANode::render_as_module(Samples **audio_out,
 	EDL *edl = vconsole->renderengine->get_edl();
 	const int debug = 0;
 
-// Process last subnode.  This calls read_data, propogates up the chain 
+// Process last subnode.  This calls read_data, propagates up the chain 
 // of subnodes, and finishes the chain.
 	if(subnodes.total)
 	{

--- a/cinelerra/virtualconsole.C
+++ b/cinelerra/virtualconsole.C
@@ -100,7 +100,7 @@ Module* VirtualConsole::module_of(Track *track)
 
 Module* VirtualConsole::module_number(int track_number)
 {
-// The track number is an absolute number of the track independant of
+// The track number is an absolute number of the track independent of
 // the tracks with matching data type but virtual modules only exist for
 // the matching data type.
 // Convert from absolute track number to data type track number.

--- a/cinelerra/virtualvnode.C
+++ b/cinelerra/virtualvnode.C
@@ -137,8 +137,8 @@ int VirtualVNode::read_data(VFrame *output_temp,
 	}
 
 
-// This is a plugin on parent module with a preceeding effect.
-// Get data from preceeding effect on parent module.
+// This is a plugin on parent module with a preceding effect.
+// Get data from preceding effect on parent module.
 	if(parent_node && (previous_plugin = parent_node->get_previous_plugin(this)))
 	{
 		result = ((VirtualVNode*)previous_plugin)->render(output_temp,
@@ -280,7 +280,7 @@ int VirtualVNode::render_as_module(VFrame *video_out,
 
 	output_temp->push_next_effect("VirtualVNode::render_as_module");
 
-// Process last subnode.  This propogates up the chain of subnodes and finishes
+// Process last subnode.  This propagates up the chain of subnodes and finishes
 // the chain.
 	if(subnodes.total)
 	{

--- a/doc/about.texi
+++ b/doc/about.texi
@@ -77,7 +77,7 @@ not strictly adhering to standard features has been the biggest source
 of contention.
 
 As with Broadcast 2000, most users oppose this program being distributed
-without full support, full patch debugging & integration, adherance to
+without full support, full patch debugging & integration, adherence to
 standard features, & want it taken down.  Whether someone should be
 allowed to do their own thing is an ages old question.  Other projects
 got ahead of the support problem from the beginning by raising enough

--- a/doc/application_notes.texi
+++ b/doc/application_notes.texi
@@ -117,7 +117,7 @@ techniques involve deinterlacing.
 
 Interlacing is done on most video sources because it costs too much to
 build progressive scanning cameras and progressive scanning CRT's. 
-Many a consumer has been dissapointed to spend 5 paychecks on a
+Many a consumer has been disappointed to spend 5 paychecks on a
 camcorder and discover what horrible jagged images it produces on a
 computer monitor.
 

--- a/doc/compositing.texi
+++ b/doc/compositing.texi
@@ -357,7 +357,7 @@ track.
 @section TRACK AND OUTPUT SIZES
 
 The size of the temporary and the size of the output in our compositing
-pipeline are independant and variable.  This fits into everything
+pipeline are independent and variable.  This fits into everything
 covered so far.  The camera's viewport is the temporary size.  Effects
 are processed in the temporary and are affected by the temporary size. 
 Projectors are rendered to the output and are affected by the output

--- a/doc/configuration.html
+++ b/doc/configuration.html
@@ -5,7 +5,7 @@
 
 Because of the variety of uses, Cinelerra can not be run optimally
 without some intimate configuration for your specific needs. Very few
-parameters are adjustible at compile time.  Runtime configuration is
+parameters are adjustable at compile time.  Runtime configuration is
 the only option for most configuration because of the multitude of
 parameters.<P>
 
@@ -198,7 +198,7 @@ device.  When this is set to 2 and the record operation has 1 channel
 you'll record the left speaker and not a mix of the left and right
 speakers as expected for a monaural project.  When this is set to 1 and
 the project has 2 channels you'll record the left and right channels
-mixed into the left speaker and not 1 channel spead across two
+mixed into the left speaker and not 1 channel spread across two
 speakers.<P>
 </BLOCKQUOTE>
 
@@ -250,7 +250,7 @@ forces Linux to flush its buffers every second instead of every few
 minutes and produce slightly better realtime behavior.<P>
 
 <B>SIZE OF CAPTURED FRAME:</B> - This is the size of the frames
-recorded.  It is independant of the project frame size because most
+recorded.  It is independent of the project frame size because most
 video devices only record a fixed frame size.  If the frame size given
 here isn't supported by the device it might crash Cinelerra.<P>
 
@@ -306,14 +306,14 @@ reopened more frequently.<P>
 <B>SECONDS TO PREROLL RENDERS:</B> - Some effects need a certain amount
 of time to settle in.  This sets a number of seconds to render without
 writing to disk before the selected region is rendered.  When using the
-renderfarm you'll sometimes need to preroll to get seemless transitions
+renderfarm you'll sometimes need to preroll to get seamless transitions
 between the jobs.  Every job in a renderfarm is prerolled by this
 value.<P>
 
 <B>FORCE SINGLE PROCESSOR USE:</B> - Cinelerra tries to use all
 processors on the system by default but sometimes you'll only want to
 use one processor, like in a renderfarm client.  This forces only one
-processer to be used.  The operating system, however, usually uses the
+processor to be used.  The operating system, however, usually uses the
 second processor anyway for disk access so this option is really a 1.25
 processor mode.<P>
 
@@ -390,7 +390,7 @@ disables the thumbnails.<P>
 
 <B>CLICKING IN/OUT POINTS DOES WHAT:</B> - Cinelerra not only allows
 you to perform editing by dragging in/out points but also defines three
-seperate operations which occur when you drag an in/out point. For each
+separate operations which occur when you drag an in/out point. For each
 mouse button you select the behavior in this window. The usage of each
 editing mode is described in editing.<P>
 

--- a/doc/configure.texi
+++ b/doc/configure.texi
@@ -7,7 +7,7 @@
 
 Because of the variety of uses, Cinelerra cannot be run optimally
 without some intimate configuration for your specific needs. Very few
-parameters are adjustible at compile time.  Runtime configuration is
+parameters are adjustable at compile time.  Runtime configuration is
 the only option for most configuration because of the multitude of
 parameters.
 
@@ -266,7 +266,7 @@ sizes up to the maximum texture size, which is usually larger than
 
 Today, the rendering as well as the playback can be done in OpenGL.  It
 relies on PBuffers and shaders to do video rendering.  The graphics
-driver must support OpenGL 2 and Cinelerra needs to be explicitely
+driver must support OpenGL 2 and Cinelerra needs to be explicitly
 compiled with OpenGL 2 support.  This requires compiling it on a system
 with the OpenGL 2 headers.
 
@@ -725,7 +725,7 @@ realtime behavior.
 
 @b{SIZE OF CAPTURED FRAME}
 
-This is the size of the frames recorded.  It is independant of the
+This is the size of the frames recorded.  It is independent of the
 project frame size because most video devices only record a fixed frame
 size.  If the frame size given here isn't supported by the device it
 might crash Cinelerra.
@@ -867,7 +867,7 @@ SECONDS TO PREROLL RENDERS
 Some effects need a certain amount of time to settle in.  This sets a
 number of seconds to render without writing to disk before the selected
 region is rendered.  When using the renderfarm you'll sometimes need to
-preroll to get seemless transitions between the jobs.  Every job in a
+preroll to get seamless transitions between the jobs.  Every job in a
 renderfarm is prerolled by this value.  This does not affect background
 rendering, however.  Background rendering uses a different preroll
 value.
@@ -878,7 +878,7 @@ FORCE SINGLE PROCESSOR USE
 
 Cinelerra tries to use all processors on the system by default but
 sometimes you'll only want to use one processor, like in a renderfarm
-client.  This forces only one processer to be used.  The operating
+client.  This forces only one processor to be used.  The operating
 system, however, usually uses the second processor anyway for disk
 access so this option is really a 1.25 processor mode.  The value of
 this parameter is used in renderfarm clients.
@@ -906,7 +906,7 @@ in the GPU.
 @node BACKGROUND RENDERING
 @subsection BACKGROUND RENDERING
 
-Background rendering was originally concieved to allow HDTV effects to
+Background rendering was originally conceived to allow HDTV effects to
 be displayed in realtime.  Background rendering causes temporary output
 to constantly be rendered while the timeline is being modified.  The
 temporary output is played during playack whenever possible.  It's very
@@ -1119,13 +1119,13 @@ DELETE ALL INDEXES
 When you change the index size or you want to clean out excessive index
 files, this deletes all the index files.
 
-@item TIME STRECH SCRUBBING
+@item TIME STRETCH SCRUBBING
 
 Scrubbing of audio with the transport controls (@xref{USING THE
 TRANSPORT CONTROLS}) can either use tape style pitch stretching or time
 stretching with constant pitch.  The time stretching mode is more
 intelligible but pitch stretching is the traditional sound a tape deck
-would have made.  Time strech scrubbing does not have all the options or
+would have made.  Time stretch scrubbing does not have all the options or
 use a fast fourier transform like the Time Stretch effect (@xref{TIME
 STRETCHING AUDIO}).
 

--- a/doc/current.html
+++ b/doc/current.html
@@ -10,7 +10,7 @@
 <LI>6 time representations</LI>
 <LI>Gang faders</LI>
 <LI>Rubber band fader automation - not rendered right</LI>
-<LI>8 color models - alpha channels not transfered to X11 right</LI>
+<LI>8 color models - alpha channels not transferred to X11 right</LI>
 <LI>Cut, copy, paste, clear of media</LI>
 <LI>Cut, copy, paste, clear of keyframes</LI>
 <LI>Aspect ratio adjustment</LI>

--- a/doc/development.texi
+++ b/doc/development.texi
@@ -112,9 +112,9 @@ include @b{pluginaclient.h} and video plugins include
 
 Cinelerra instantiates all plugins at least twice when they are used in
 a movie.  One instance is the GUI.  The other instance is the rendering
-processor.  User input, through a complicated sequence, is propogated
+processor.  User input, through a complicated sequence, is propagated
 from the GUI instance to the rendering instance.  If the renderer wants
-to alter the GUI, it propogates data back to the GUI instance.  
+to alter the GUI, it propagates data back to the GUI instance.  
 
 All plugins define at least three objects:
 
@@ -340,7 +340,7 @@ depending on the plugin type.
 The configuration object is critical for GUI updates, signal
 processing, and default settings in realtime plugins.  Be aware it is
 not used in nonrealtime plugins.  The configuration object inherits
-from nothing and has no dependancies.  It's merely a class containing
+from nothing and has no dependencies.  It's merely a class containing
 three functions and variables specific to the plugin's parameters.
 
 Usually the configuration object starts with the name of the plugin
@@ -379,7 +379,7 @@ required functions and the configuration variables.
 Now you must define the three functions.  @b{Equivalent} is called by
 LOAD_CONFIGURATION_MACRO to determine if the local configuration
 parameters are identical to the configuration parameters in the
-arguement.  If equivalent returns 0, the LOAD_CONFIGURATION_MACRO 
+argument.  If equivalent returns 0, the LOAD_CONFIGURATION_MACRO 
 causes the GUI to redraw.  If equivalent returns 1, the
 LOAD_CONFIGURATION_MACRO doesn't redraw the GUI.
 
@@ -515,7 +515,7 @@ to make the window appear all at once.
 Every widget in the GUI needs to detect when its value changes.  In
 GuiCast the @b{handle_event} method is called whenever the value
 changes.  In @b{handle_event}, the widget then needs to call
-@b{plugin->send_configure_change()} to propogate the change to any
+@b{plugin->send_configure_change()} to propagate the change to any
 copies of the plugin which are processing data.
 
 
@@ -594,7 +594,7 @@ supplied to process_buffer if you don't need a temporary.
 
 It also needs a set of position arguments to determine when you want to
 read the data from.  The start position, rate, and len passed to a read
-function need not be the same as the values recieved by the
+function need not be the same as the values received by the
 process_buffer function.  This way plugins can read data at a different
 rate than they output data.
 
@@ -893,7 +893,7 @@ PLUGIN_DESTRUCTOR_MACRO to initialize the processing object.  You'll
 also need a BC_Hash object and a Thread object for these macros.
 
 Since the GUI is optional, overwrite a function called @b{uses_gui()}
-to signifiy whether or not the transition has a GUI.  Return 1 if it
+to signify whether or not the transition has a GUI.  Return 1 if it
 does and 0 if it doesn't.
 
 Transitions need a @b{load_defaults} and @b{save_defaults} function so
@@ -1085,7 +1085,7 @@ plugin needs to process.
 There are two rates for media a realtime plugin has to be aware of: the
 project rate and the requested rate.  Functions are provided for
 getting the project and requested rate.  In addition, doing time
-dependant effects requires using several functions which tell where you
+dependent effects requires using several functions which tell where you
 are in the effect.
 
 @itemize
@@ -1455,7 +1455,7 @@ attached with calls to @b{next_effect_is} and @b{prev_effect_is}.
 These take the name of the processor plugin as a string argument and
 return 1 if the next or previous plugin is the processor plugin.  If
 either returns 1, the fall through plugin must still call @b{read_frame} to
-propogate the data but return after that.
+propagate the data but return after that.
 
 The processor plugin must call @b{next_effect_is} and
 @b{prev_effect_is} to determine if it's aggregated with a fall through

--- a/doc/editing.texi
+++ b/doc/editing.texi
@@ -282,7 +282,7 @@ specifically can't store high frequencies in most cases.
 
 Tracks in Cinelerra either contain audio or video.  There is no special
 designation for tracks other than the type of media they contain.  When
-you create a new project, it contains a certain mumber of default
+you create a new project, it contains a certain number of default
 tracks.  You can still add or delete tracks from a number of menus. 
 The @b{Tracks} menu contains a number of options for dealing with
 multiple tracks simultaneously.  Each track itself has a popup menu
@@ -593,7 +593,7 @@ without changing the relative start and stop positions.
 
 One option for simplifying this is to open a second copy of Cinelerra,
 cutting and pasting to transport media between the two copies.  This
-way two highlighed regions can exist simultanously.
+way two highlighted regions can exist simultaneously.
 
 Another option is to set in/out points for the source region of the
 source waveform and set labels for the destination region of the

--- a/doc/effects.texi
+++ b/doc/effects.texi
@@ -48,7 +48,7 @@ utilize fully by mere experimentation.
 @section 1080 TO 480
 
 
-Most TV broadcasts are recieved with a 1920x1080 resolution but
+Most TV broadcasts are received with a 1920x1080 resolution but
 originate from a 720x480 source at the studio.  It's a waste of space
 to compress the entire 1920x1080 if the only resolvable details are
 720x480.  Unfortunately resizing 1920x1080 video to 720x480 isn't as
@@ -154,7 +154,7 @@ range is the user specified value.
 
 The compressor has a graph which correlates every input sound level to
 an output level.  The horizontal direction is the input sound level in
-dB.  The vertical direction is the ouptut sound level in dB.  The user
+dB.  The vertical direction is the output sound level in dB.  The user
 specifies output sound levels by creating points on the graph.  Click in
 the graph to create a point.  If 2 points exist, drag one point across
 another point to delete it.  The most recent point selected has its
@@ -369,7 +369,7 @@ can soften the transparency border.
 @section FIELDS TO FRAMES
 
 This effects reads frames at twice the project framerate, combining 2
-input frames into a single interlaced output frame.  Effects preceeding
+input frames into a single interlaced output frame.  Effects preceding
 @b{fields to frames} process frames at twice the project frame rate. 
 Each input frame is called a field.
 
@@ -424,7 +424,7 @@ disabled regions play through.
 @section HISTOGRAM
 
 
-This shows the number of occurances of each color on a histogram plot.
+This shows the number of occurrences of each color on a histogram plot.
 
 It is always performed in floating point RGB regardless of
 the project colorspace.  The histogram has two sets of transfer
@@ -803,7 +803,7 @@ length of output video by the inverse of the scale factor.  If the
 scale factor is greater than 1, the output will end before the end of
 the sequence on the timeline.  If it's less than 1, the output will end
 after the end of the sequence on the timeline.  The ReframeRT effect
-must be lengthened to the necessary length to accomodate the scale
+must be lengthened to the necessary length to accommodate the scale
 factor.  Change the length of the effect by clicking on the endpoint of
 the effect and dragging.
 
@@ -892,7 +892,7 @@ you to set keyframes.  This allows may possibilities.
 
 Every @b{enabled} keyframe is treated as the start of a new reversed
 region and the end of a previous reversed region.  Several @b{enabled}
-keyframes in succession yield several regions reversed independant of
+keyframes in succession yield several regions reversed independent of
 each other.  An @b{enabled} keyframe followed by a @b{disabled}
 keyframe yields one reversed region followed by a forward region.
 
@@ -958,7 +958,7 @@ Inside the time average effect is an accumulation buffer and a
 divisor.  A number of frames are accumulated in the accumulation buffer
 and divided by the divisor to get the average.
 
-Because the time average can consume enourmous amounts of memory, it is
+Because the time average can consume enormous amounts of memory, it is
 best applied by first disabling playback for the track, dropping the
 time average in it, configuring time average for the desired number of
 frames, and re-enabling playback for the track.
@@ -1036,7 +1036,7 @@ be justified while at the same time letting you push it within the
 title safe region.
 
 The @b{motion type} scrolls the text in any of the four directions. 
-When using this, the text may dissappear.  Move the insertion point
+When using this, the text may disappear.  Move the insertion point
 along the timeline until the text is far enough along the animation to
 reappear.  The text scrolls on and scrolls off.
 

--- a/doc/install.texi
+++ b/doc/install.texi
@@ -4,7 +4,7 @@
 
 
 The Cinelerra package contains Cinelerra and most of the libraries
-needed to run it.  We try to include all the dependancies because of
+needed to run it.  We try to include all the dependencies because of
 the difficulty in tracking down the right versions.  Also included are
 some utilities for handling files.  The following are the general
 contents of all Cinelerra packages.

--- a/doc/keyframes.texi
+++ b/doc/keyframes.texi
@@ -108,7 +108,7 @@ variability.  This is done by 2 tools: the automation fit button
 
 The automation fit button scales and offsets the vertical range so the
 selected curves fit in the timeline.  The selected curves are defined by
-the armed tracks, the visible keyframe types, & the highlighed region. 
+the armed tracks, the visible keyframe types, & the highlighted region. 
 If a region of the timeline is highlighted by the cursor, only that
 region is scaled.  If a region is not highlighted, the entire project is
 scaled.  In/out points don't affect the zoomed region.  @b{Alt-f} also
@@ -210,7 +210,7 @@ timeline is playing back during a tweek, several automatic keyframes
 will be generated as you change the parameter.
 
 When automatic keyframe mode is disabled, adjusting a parameter adjusts
-the keyframe immediately preceeding the insertion point.  If two fade
+the keyframe immediately preceding the insertion point.  If two fade
 keyframes exist and the insertion point is between them, changing the
 fader changes the first keyframe.
 
@@ -228,7 +228,7 @@ because they require too many data points to draw on the timeline.
 Camera and projector translation can only be keyframed in automatic
 keyframe mode while camera and projector zoom can be keyframed with
 curves.  It is here that we conclude the discussion of compositing,
-since compositing is highly dependant on the ability to change over
+since compositing is highly dependent on the ability to change over
 time.
 @end ignore
 
@@ -279,7 +279,7 @@ keyframe menus.
 
 @ignore
 @b{Ctrl-drag} to set either the in or out control point of the
-preceeding keyframe.  Once again, we depart from The Gimp because
+preceding keyframe.  Once again, we depart from The Gimp because
 @b{shift} is already used for zoom.  After the in or out control points
 are extrapolated from the keyframe, @b{Ctrl-dragging} anywhere in the
 video adjusts the nearest control point.  A control point can be out of
@@ -370,7 +370,7 @@ number of reflections in Reverb.
 @b{THE KEYFRAME MENU}
 
 Keyframes can be shifted around and moved between tracks on the timeline
-using the same cut and paste metaphore as editing media.  The
+using the same cut and paste metaphor as editing media.  The
 @b{keyframe} menu performs clipboard operations on multiple keyframes at
 the same time, as defined by what tracks are armed & what data types are
 visible.  Only the keyframes selected in the @b{view} menu are affected
@@ -413,7 +413,7 @@ keyframe reflected until all the non-default keyframes are removed.
 
 Finally, there is a convenient way to delete keyframes besides
 selecting a region and calling @b{keyframes->clear keyframes}. 
-Merely click-drag a keyframe before its preceeding keyframe or after
+Merely click-drag a keyframe before its preceding keyframe or after
 its following keyframe on the track.
 
 @b{KEYFRAME CONTEXT MENU}

--- a/doc/motion.texi
+++ b/doc/motion.texi
@@ -187,7 +187,7 @@ vector.  The absolute motion vector for each frame replaces the
 absolute motion vector for the previous frame.  Settling speed has no
 effect on it since it doesn't contain any previous motion vectors. 
 Playback can start anywhere on the timeline since there is no
-dependance on previous results.
+dependence on previous results.
 
 @item
 

--- a/doc/navigation.texi
+++ b/doc/navigation.texi
@@ -24,7 +24,7 @@ track and getting to a certain time in the track.
 
 The program window contains many features for navigation and displays
 the timeline as it is structured in memory: tracks stacked vertically
-and extending across time horizontall.  The horizontal scroll bar
+and extending across time horizontal.  The horizontal scroll bar
 allows you to scan across time.  The vertical scroll bar allows you to
 scan across tracks.
 

--- a/doc/project_settings.texi
+++ b/doc/project_settings.texi
@@ -79,7 +79,7 @@ them have the same output.
 @section COLOR MODEL
 
 Color model is very important for video playback because video has the
-disadvantage of being very slow.  Although it isn't noticable, audio
+disadvantage of being very slow.  Although it isn't noticeable, audio
 intermediates contain much more information than the audio on disk and
 the audio which is played.  Audio always uses the highest bandwidth
 intermediate because it's fast.

--- a/doc/troubleshooting.texi
+++ b/doc/troubleshooting.texi
@@ -30,7 +30,7 @@ buffer in device} is below 10.
 
 
 Sometimes there will be two edits really close together.  The point
-selected for dragging may be next to the indended edit on an edit too
+selected for dragging may be next to the intended edit on an edit too
 small to see at the current zoom level.  Zoom in horizontally.
 
 

--- a/doc/using_effects.texi
+++ b/doc/using_effects.texi
@@ -105,7 +105,7 @@ entire duration of the effect.
 @subsection REALTIME EFFECT TYPES
 
 The two other effect types supported by the Attach Effect dialog are
-recycled effects.  In order to use a recycled effect, three requiremenets
+recycled effects.  In order to use a recycled effect, three requiremeents
 must be met:
 
 @itemize

--- a/guicast/bccmodels.h.bak
+++ b/guicast/bccmodels.h.bak
@@ -59,7 +59,7 @@
 #define BC_YUV422P      17
 #define BC_YUV444P      27
 #define BC_YUV411P      18
-#define BC_YUV9P        28     // Disasterous cmodel from Sorenson
+#define BC_YUV9P        28     // Disastrous cmodel from Sorenson
 #define BC_YUV420P10LE  32
 #define BC_NV12         33     // Y plane, interleaved UV plane
 #define BC_NV21         34     // Y plane, interleaved VU plane
@@ -249,7 +249,7 @@ public:
 		int out_h,
 		int in_colormodel, 
 		int out_colormodel,
-		int bg_color,         /* When transfering BC_RGBA8888 to non-alpha this is the background color in 0xRRGGBB hex */
+		int bg_color,         /* When transferring BC_RGBA8888 to non-alpha this is the background color in 0xRRGGBB hex */
 		int in_rowspan,       /* For planar use the luma rowspan */
 		int out_rowspan);     /* For planar use the luma rowspan */
 

--- a/guicast/bchash.C
+++ b/guicast/bchash.C
@@ -59,7 +59,7 @@ int BC_Hash::load()
 void BC_Hash::load_stringfile(StringFile *file)
 {
 	char key[BCTEXTLEN], value[BCTEXTLEN];
-// keys previously loaded by this function with the number of occurrances
+// keys previously loaded by this function with the number of occurrences
 // can't force update to always append since this function has to overwrite
     std::map<string, int> instances;
 

--- a/guicast/bcmeter.h
+++ b/guicast/bcmeter.h
@@ -56,7 +56,7 @@ public:
 
 	int initialize();
 	int set_delays(
-// Number of updates before over dissappears
+// Number of updates before over disappears
 		int over_delay, /* = 150, */
 // Number of updates before peak updates
 		int peak_delay /* = 15 */);

--- a/guicast/bctheme.h
+++ b/guicast/bctheme.h
@@ -119,7 +119,7 @@ private:
 	char path[BCTEXTLEN];
 	char default_path[BCTEXTLEN];
 
-// Individial compressed images
+// Individual compressed images
 	std::map<std::string, uint8_t*> images;
 // optimize search for the last image
 	const char *last_image;

--- a/guicast/bcwindowbase.h
+++ b/guicast/bcwindowbase.h
@@ -681,7 +681,7 @@ private:
 	int untrigger_tooltip();
 	void draw_tooltip();
 	int arm_repeat(int64_t duration);
-// delete all repeater opjects for a close
+// delete all repeater objects for a close
 	int unset_all_repeaters();
 
 // Block and get event from common events.

--- a/guicast/bcwindowevents.h
+++ b/guicast/bcwindowevents.h
@@ -25,7 +25,7 @@
 // Thread running parallel to run_window which listens for X server events 
 // only.  Hopefully, having it as the only thing calling the X server without 
 // locks won't crash.  Previously, events were dispatched from BC_Repeater 
-// asynchronous to the events recieved by XNextEvent.  BC_Repeater tended to
+// asynchronous to the events received by XNextEvent.  BC_Repeater tended to
 // lock up for no reason.
 
 

--- a/guicast/colormodels.h
+++ b/guicast/colormodels.h
@@ -60,7 +60,7 @@
 #define BC_YUV422P      17
 #define BC_YUV444P      27
 #define BC_YUV411P      18
-#define BC_YUV9P        28 // Disasterous cmodel from Sorenson
+#define BC_YUV9P        28 // Disastrous cmodel from Sorenson
 #define BC_YUV420P10LE  32
 #define BC_NV12         33 // Y plane, interleaved UV plane
 #define BC_NV21         34 // Y plane, interleaved VU plane
@@ -244,7 +244,7 @@ void cmodel_transfer(unsigned char **output_rows, /* Leave NULL if non existent 
 	int out_h,
 	int in_colormodel, 
 	int out_colormodel,
-	int bg_color,         /* When transfering BC_RGBA8888 to non-alpha this is the background color in 0xRRGGBB hex */
+	int bg_color,         /* When transferring BC_RGBA8888 to non-alpha this is the background color in 0xRRGGBB hex */
 	int in_rowspan,       /* For planar use the luma rowspan */
 	int out_rowspan);     /* For planar use the luma rowspan */
 

--- a/guicast/colormodels2.h
+++ b/guicast/colormodels2.h
@@ -59,7 +59,7 @@
 #define BC_YUV444P      27
 #define BC_YUVA444P     37
 #define BC_YUV411P      18
-#define BC_YUV9P        28 // Disasterous cmodel from Sorenson
+#define BC_YUV9P        28 // Disastrous cmodel from Sorenson
 #define BC_YUV420P10LE  32
 #define BC_NV12         33 // Y plane, interleaved UV plane
 #define BC_NV21         34 // Y plane, interleaved VU plane
@@ -220,7 +220,7 @@ void cmodel_transfer(unsigned char **output_rows, /* Leave NULL if non existent 
 	int out_h,
 	int in_colormodel, 
 	int out_colormodel,
-	int bg_color,         /* When transfering BC_RGBA8888 to non-alpha this is the background color in 0xRRGGBB hex */
+	int bg_color,         /* When transferring BC_RGBA8888 to non-alpha this is the background color in 0xRRGGBB hex */
 	int in_rowspan,       /* For planar use the luma rowspan */
 	int out_rowspan);     /* For planar use the luma rowspan */
 

--- a/guicast/filesystem.C
+++ b/guicast/filesystem.C
@@ -471,7 +471,7 @@ int FileSystem::update(const char *new_dir)
 	{
 		include_this = 1;
 
-// File is directory heirarchy
+// File is directory hierarchy
 		if(!strcmp(new_filename->d_name, ".") || 
 			!strcmp(new_filename->d_name, "..")) include_this = 0;
 

--- a/guicast/vframe.h
+++ b/guicast/vframe.h
@@ -302,7 +302,7 @@ public:
 // Requires a null terminated argument list of shaders to link together.
 // At least one shader argument must have a main() function.  make_shader
 // replaces all the main() functions with unique functions and calls them in
-// sequence, so multiple independant shaders can be linked.
+// sequence, so multiple independent shaders can be linked.
 	static unsigned int make_shader(int dump, ...);
 	static void dump_shader(int shader_id);
 

--- a/guicast/vframe3d.C
+++ b/guicast/vframe3d.C
@@ -630,7 +630,7 @@ unsigned int VFrame::make_shader(int dump, ...)
 		char *text = va_arg(list, char*);
 		if(!text) break;
 
-// Replace one occurrance in each source of main() with a unique id.
+// Replace one occurrence in each source of main() with a unique id.
 		char main_replacement[BCTEXTLEN];
 		sprintf(main_replacement, "main%03d()", current_shader);
 //printf("VFrame::make_shader %s %s\n", text, main_replacement);

--- a/make_packages
+++ b/make_packages
@@ -136,7 +136,7 @@ rm -r $CI_NAME/thirdparty/festival $CI_NAME/thirdparty/speech_tools $CI_NAME/thi
 find $CI_NAME/ -name CMakeCache.txt -exec rm {} \;
 find $CI_NAME -name .svn -exec rm -rf {} \; -prune
 find $CI_NAME -name .git -exec rm -rf {} \; -prune
-# dependancies are created in some clean rules
+# dependencies are created in some clean rules
 find $CI_NAME -name '*.d' -exec rm {} \;
 tar Jcf $CI_NAME-src.tar.xz $CI_NAME
 

--- a/plugins/blur/blur.h
+++ b/plugins/blur/blur.h
@@ -161,7 +161,7 @@ public:
 	int terms;
     int size;
 	BlurMain *plugin;
-// A margin is introduced between the input and output to give a seemless transition between blurs
+// A margin is introduced between the input and output to give a seamless transition between blurs
 	int start_y, start_x;
 	int end_y, end_x;
 	int last_frame;

--- a/plugins/curves/curves.C
+++ b/plugins/curves/curves.C
@@ -389,9 +389,9 @@ float CurvesMain::calculate_bezier(curve_point_t *p1,
 /*
  * the x values of the inner control points are fixed at
  * x1 = 2/3*x0 + 1/3*x3   and  x2 = 1/3*x0 + 2/3*x3
- * this ensures that the x values increase linearily with the
+ * this ensures that the x values increase linearly with the
  * parameter t and enables us to skip the calculation of the x
- * values altogehter - just calculate y(t) evenly spaced.
+ * values altogether - just calculate y(t) evenly spaced.
  */
 
     dx = x3 - x0;
@@ -447,7 +447,7 @@ float CurvesMain::calculate_bezier(curve_point_t *p1,
 
     /*
      * finally calculate the y(t) values for the given bezier values. We can
-     * use homogenously distributed values for t, since x(t) increases linearily.
+     * use homogeneously distributed values for t, since x(t) increases linearly.
      */
     float y, t;
 

--- a/plugins/curves/curves.sl
+++ b/plugins/curves/curves.sl
@@ -45,7 +45,7 @@ float calculate_bezier(int p1,
 /*
  * the x values of the inner control points are fixed at
  * x1 = 2/3*x0 + 1/3*x3   and  x2 = 1/3*x0 + 2/3*x3
- * this ensures that the x values increase linearily with the
+ * this ensures that the x values increase linearly with the
  * parameter t and enables us to skip the calculation of the x
  * values altogehter - just calculate y(t) evenly spaced.
  */
@@ -103,7 +103,7 @@ float calculate_bezier(int p1,
 
     /*
      * finally calculate the y(t) values for the given bezier values. We can
-     * use homogenously distributed values for t, since x(t) increases linearily.
+     * use homogeneously distributed values for t, since x(t) increases linearly.
      */
     float y, t;
 

--- a/plugins/dissolve/dissolve.C
+++ b/plugins/dissolve/dissolve.C
@@ -71,7 +71,7 @@ int DissolveMain::process_realtime(VFrame *incoming, VFrame *outgoing)
 	if(!overlayer) overlayer = new OverlayFrame(get_project_smp() + 1);
 
 // There is a problem when dissolving from a big picture to a small picture.
-// In order to make it dissolve correctly, we have to manually decrese alpha of big picture.
+// In order to make it dissolve correctly, we have to manually decrease alpha of big picture.
 // 	switch (outgoing->get_color_model())
 // 	{
 // 		case BC_RGBA8888:

--- a/plugins/findobject/findobject.C
+++ b/plugins/findobject/findobject.C
@@ -1037,7 +1037,7 @@ void FindObjectMain::process_blob()
         blob_param.pBD = cvCreateBlobDetectorCC();
 /* Create blob tracker module: */
         blob_param.pBT = cvCreateBlobTrackerCCMSPF();
-/* Create whole pipline: */
+/* Create whole pipeline: */
         blob_pTracker = cvCreateBlobTrackerAuto1(&blob_param);
 		
 	}

--- a/plugins/histogram_bezier/histogram.C
+++ b/plugins/histogram_bezier/histogram.C
@@ -480,7 +480,7 @@ float HistogramMain::calculate_linear(float input,
 		  }
 		  else if (config.smoothMode == HISTOGRAM_BEZIER)
 		  {
-		  	/* Using standart DeCasteljau algorithm */
+		  	/* Using standard DeCasteljau algorithm */
 		  	float y1right = y1 + grad1 * x1right;
 		  	float y2left = y2 + grad2 * x2left;
 

--- a/plugins/hyperlapse/hyperlapse.C
+++ b/plugins/hyperlapse/hyperlapse.C
@@ -287,7 +287,7 @@ int Hyperlapse::process_buffer(VFrame *frame,
 	}
 	
 
-// move currrent image to previous position
+// move current image to previous position
 	if(next_position >= 0 && next_position == actual_previous_number)
 	{
 		IplImage *temp = prev_image;

--- a/plugins/livevideo/livevideo.C
+++ b/plugins/livevideo/livevideo.C
@@ -506,7 +506,7 @@ int LiveVideo::process_buffer(VFrame *frame,
 					h,
 					input->get_color_model(), 
 					frame->get_color_model(),
-					0,         /* When transfering BC_RGBA8888 to non-alpha this is the background color in 0xRRGGBB hex */
+					0,         /* When transferring BC_RGBA8888 to non-alpha this is the background color in 0xRRGGBB hex */
 					input->get_bytes_per_line(),       /* For planar use the luma rowspan */
 					frame->get_bytes_per_line());     /* For planar use the luma rowspan */
 				frame->set_opengl_state(VFrame::RAM);

--- a/plugins/motion.bak/motionscan.C
+++ b/plugins/motion.bak/motionscan.C
@@ -637,7 +637,7 @@ global_origin_angle);
 		block_y1 += total_dy / OVERSAMPLE;
 		block_x2 += total_dx / OVERSAMPLE;
 		block_y2 += total_dy / OVERSAMPLE;
-// Rotation is independant of accumulated angle
+// Rotation is independent of accumulated angle
 //		this->scan_angle1 += total_angle;
 //		this->scan_angle2 += total_angle;
 	}

--- a/plugins/normalize/normalizewindow.C
+++ b/plugins/normalize/normalizewindow.C
@@ -84,7 +84,7 @@ int NormalizeWindowOverload::handle_event()
 
 
 NormalizeWindowSeparate::NormalizeWindowSeparate(int x, int y, int *separate_tracks)
- : BC_CheckBox(x, y, *separate_tracks, _("Treat tracks independantly"))
+ : BC_CheckBox(x, y, *separate_tracks, _("Treat tracks independently"))
 {
 	this->separate_tracks = separate_tracks;
 }

--- a/plugins/reframert/reframert.C
+++ b/plugins/reframert/reframert.C
@@ -455,7 +455,7 @@ void ReframeRT::save_data(KeyFrame *keyframe)
 // cause data to be stored directly in text
 	output.set_shared_string(keyframe->get_data(), MESSAGESIZE);
 	output.tag.set_title("REFRAMERT");
-// for backwards compatability, we call num scale
+// for backwards compatibility, we call num scale
 	output.tag.set_property("SCALE", config.num);
 	output.tag.set_property("DENOM", config.denom);
 	output.tag.set_property("STRETCH", config.stretch);
@@ -475,7 +475,7 @@ void ReframeRT::read_data(KeyFrame *keyframe)
 	{
 		if(input.tag.title_is("REFRAMERT"))
 		{
-// for backwards compatability, we call num scale
+// for backwards compatibility, we call num scale
 			config.num = input.tag.get_property("SCALE", config.num);
 			config.denom = input.tag.get_property("DENOM", config.denom);
 			config.stretch = input.tag.get_property("STRETCH", config.stretch);

--- a/plugins/titler/title.C.stroker
+++ b/plugins/titler/title.C.stroker
@@ -279,7 +279,7 @@ void GlyphUnit::process_package(LoadPackage *package)
 // Char not found
 		if (gindex == 0) 
 		{
-// carrige return
+// carriage return
 			if (glyph->char_code != 10)  
 				printf(_("GlyphUnit::process_package FT_Load_Char failed - char: %i.\n"),
 					glyph->char_code);

--- a/quicktime/docs/positioning.html
+++ b/quicktime/docs/positioning.html
@@ -4,8 +4,8 @@
 
 The library stores a seperate position identifier for each video track
 and each audio track in a file.  The position identifiers are
-independant of each other and advance independantly when you read
-data.  Video tracks advance independantly, but audio tracks are
+independant of each other and advance independently when you read
+data.  Video tracks advance independently, but audio tracks are
 tricky.  When you read audio data, the channel positions are not
 independant.  Since all the channels are on track 0, reading audio data
 advances all the channel positions.  You need to manually set the audio

--- a/xmovie/mainmenu.C
+++ b/xmovie/mainmenu.C
@@ -159,7 +159,7 @@ int MainMenu::add_load(char *path)
 	{
 		if(!strcmp(load_previous[i]->get_text(), text))     // already exists
 		{                                // swap for top load
-			for(int j = i; j > 0; j--)   // move preceeding loads down
+			for(int j = i; j > 0; j--)   // move preceding loads down
 			{
 				load_previous[j]->set_text(load_previous[j - 1]->get_text());
 				load_previous[j]->set_path(load_previous[j - 1]->path);


### PR DESCRIPTION
Found via `codespell -q 3 -S "*.po,*.ps,*.pdf,./thirdparty,./quicktime,./cinelerra/CHANGELOG*" -L bih,blurr,clen,doubleclick,foundary,hda,ist,iten,mane,mor,nd,optio,parm,parms,remane,rin,spred,thirdparty,tweek,tweeks,tweeked,tweeking,wih`